### PR TITLE
Updates changie for msw removal

### DIFF
--- a/.changes/unreleased/Security-20240129-140709.yaml
+++ b/.changes/unreleased/Security-20240129-140709.yaml
@@ -1,3 +1,3 @@
-kind: Removed
+kind: Security
 body: Removed msw from devDependencies
 time: 2024-01-29T14:07:09.426728-05:00


### PR DESCRIPTION
## What changes did you make?

- Switches the msw removal to be a patch release instead of a major bump.

## Is there a ticket that you are fixing?

https://github.com/OpsLevel/backstage-plugin-backend/pull/78

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.