### PR TITLE
Uses jsonpath upgrade

### DIFF
--- a/.changes/unreleased/Fixed-20241206-144918.yaml
+++ b/.changes/unreleased/Fixed-20241206-144918.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: JSONPath version bump
+time: 2024-12-06T14:49:18.536588-06:00

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Open the `index.ts` file in the `packages/backend/src` subdirectory of your Back
 Add the following line after the end of the existing import statements:
 
 ```ts
-import opslevel from './plugins/opslevel';
+import { legacyPlugin } from '@backstage/backend-common';
 ```
 
 #### Step 3.2
@@ -51,15 +51,8 @@ import opslevel from './plugins/opslevel';
 Add the following statement to the cluster of similar statements near the top of the `main()` function:
 
 ```ts
-const opslevelEnv = useHotMemoize(module, () => createEnv('opslevel'));
-```
-
-#### Step 3.3
-
-Add the following statement to the cluster of similar statements a bit further down in the `main()` function:
-
-```ts
-apiRouter.use('/opslevel', await opslevel(opslevelEnv));
+backend.add(import('@backstage/plugin-proxy-backend'));
+backend.add(legacyPlugin('opslevel', import('./plugins/opslevel')));
 ```
 
 ### Step 4

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "supertest": "^7.0.0",
     "yalc": "^1.0.0-pre.53"
   },
+  "resolutions": {
+    "jsonpath-plus": "^10.1.0"
+  },
   "files": [
     "dist",
     "/migrations/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3165,6 +3165,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsep-plugin/assignment@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.3.0.tgz#fcfc5417a04933f7ceee786e8ab498aa3ce2b242"
+  integrity sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==
+
+"@jsep-plugin/regex@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
+  integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
+
 "@keyv/memcache@^1.3.5":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@keyv/memcache/-/memcache-1.4.1.tgz#5bd6187dc98fb543d442a9032b280d3dd730c46d"
@@ -10242,6 +10252,11 @@ jsdom@^20.0.0:
     ws "^8.11.0"
     xml-name-validator "^4.0.0"
 
+jsep@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
+  integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -10343,10 +10358,14 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz#7ad94e147b3ed42f7939c315d2b9ce490c5a3899"
-  integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
+jsonpath-plus@^10.1.0, jsonpath-plus@^7.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz#84d680544d9868579cc7c8f59bbe153a5aad54c4"
+  integrity sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==
+  dependencies:
+    "@jsep-plugin/assignment" "^1.3.0"
+    "@jsep-plugin/regex" "^1.0.4"
+    jsep "^1.4.0"
 
 jsonpath@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## What changes did you make?

- Documents the new legacy plugin install
- Bumps jsonpath to avoid critical vulnerability

## Is there a ticket that you are fixing?

[*Please link it here if so*](https://gitlab.com/jklabsinc/OpsLevel/-/issues/12526)

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.
