### PR TITLE
Fixes url parsing

### DIFF
--- a/.changes/unreleased/Fixed-20241212-144852.yaml
+++ b/.changes/unreleased/Fixed-20241212-144852.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixes high vulnerability in downstream library
+time: 2024-12-12T14:48:52.206104-06:00

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@
 
 <details>
 <summary>Collapsed Screenshots</summary>
-</details
+</details>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "yalc": "^1.0.0-pre.53"
   },
   "resolutions": {
-    "jsonpath-plus": "^10.1.0"
+    "jsonpath-plus": "^10.1.0",
+    "fast-xml-parser": "^4.2.5"
   },
   "files": [
     "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8602,17 +8602,10 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-xml-parser@4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
-  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
-  dependencies:
-    strnum "^1.0.5"
-
-fast-xml-parser@^4.3.0:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz#190f9d99097f0c8f2d3a0e681a10404afca052ff"
-  integrity sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==
+fast-xml-parser@4.2.5, fast-xml-parser@^4.2.5, fast-xml-parser@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz#2882b7d01a6825dfdf909638f2de0256351def37"
+  integrity sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
## What changes did you make?

- OpsLevel alerted us to a high security vuln in `fast-xml-parser` so this ensures the downstream systems use the right version

## Is there a ticket that you are fixing?

Nope, just prepping for release

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.
